### PR TITLE
LOGS_FILE_NAME flag error patched

### DIFF
--- a/config/engine.config.hpp
+++ b/config/engine.config.hpp
@@ -18,7 +18,7 @@
 // Comment or remove that line if you don't want the logs file.
 // Note 1: The debug mode state doesn't influence the logs file. That means this file can exist even if we are not using the debug mode.
 // Note 2: We DO NOT RECOMMEND to enable the logs file for the final users because some sensitive data such as memory addresses will be written in it!
-#define ALLOW_LOGS_FILE
+#define ENABLE_LOGS_FILE
 #define LOGS_FILE_NAME "osge.logs"
 
 // Comment or remove the lines below if you want to disable support for one/some specific operating systems.

--- a/logs/logs.handler.cpp
+++ b/logs/logs.handler.cpp
@@ -18,7 +18,7 @@ void log
         std::cout << "[log] " << log << std::endl;
     #endif
 
-    #ifdef ALLOW_LOGS_FILE
+    #ifdef ENABLE_LOGS_FILE
         write_log_file("log", log);
     #endif
 }
@@ -34,7 +34,7 @@ void error_log
         std::cerr << "[error] " << log << std::endl;
     #endif
 
-    #ifdef ALLOW_LOGS_FILE
+    #ifdef ENABLE_LOGS_FILE
         write_log_file("error", log);
     #endif
 }
@@ -50,7 +50,7 @@ void fatal_error_log
         std::cerr << "[fatal_error] " << log << std::endl;
     #endif
 
-    #ifdef ALLOW_LOGS_FILE
+    #ifdef ENABLE_LOGS_FILE
         write_log_file("fatal_error", log);
     #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -38,8 +38,10 @@ int main()
 {
     try
     {
-        if (std::filesystem::exists(LOGS_FILE_NAME)) std::filesystem::remove(LOGS_FILE_NAME); // We reset the logs file by deleting it if it already exists.
-        create_new_empty_file(LOGS_FILE_NAME);
+        #ifdef ENABLE_LOGS_FILE
+            if (std::filesystem::exists(LOGS_FILE_NAME)) std::filesystem::remove(LOGS_FILE_NAME); // We reset the logs file by deleting it if it already exists.
+            create_new_empty_file(LOGS_FILE_NAME);
+        #endif
 
         // We disable the console on Windows if we're in release mode.
         #ifndef DEBUG_MODE


### PR DESCRIPTION
* Fixed the LOGS_FILE_NAME flag error when it was commented or deleted even when the logs file was disabled (#27).
* Renamed the ALLOW_LOGS_FILE flag into ENABLE_LOGS_FILE.