### PR TITLE
Config flags warnings fix

### DIFF
--- a/config/engine.config.hpp
+++ b/config/engine.config.hpp
@@ -1,7 +1,4 @@
-#ifdef ENGINE_CONFIG_HPP
-#    undef ENGINE_CONFIG_HPP
-#endif
-
+#ifndef ENGINE_CONFIG_HPP
 #define ENGINE_CONFIG_HPP
 
 namespace EngineConfig
@@ -12,23 +9,25 @@ namespace EngineConfig
 // When DEBUG_MODE is on, OSGE enables:
 // - A console with logs in it.
 // - The Khronos validation layers (Vulkan SDK required).
-constexpr bool DEBUG_MODE = true;
+constexpr const bool DEBUG_MODE = true;
 
 // Display a message box to the user when the program crashes.
 // Set to false that flag if you don't want to use it.
 // Note: The message displayed depends on the debug mode state.
 //       - If the debug mode is active, we give the full error.
 //       - If the debug mode is NOT active, we just inform the user that it crashed and a restart is needed.
-constexpr bool USE_CRASH_ERROR_MESSAGE_BOXES = true;
+constexpr const bool USE_CRASH_ERROR_MESSAGE_BOXES = true;
 
 // Set to false that flag if you don't want the logs file.
 // Note 1: The debug mode state doesn't influence the logs file. That means this file can exist even if we are not using the debug mode.
 // Note 2: We DO NOT RECOMMEND to enable the logs file for the final users because it writes the debug mode outputs into a file!
-constexpr bool ENABLE_LOGS_FILE = true;
-constexpr char* LOGS_FILE_NAME = "osge.logs";
+constexpr const bool ENABLE_LOGS_FILE = true;
+constexpr const char* LOGS_FILE_NAME = "osge.logs";
 
 // Set to false the flags below if you want to disable support for one/some specific operating systems.
-constexpr bool HANDLE_LINUX_SYSTEMS = true;
-constexpr bool HANDLE_WINDOWS_SYSTEMS = true;
+constexpr const bool HANDLE_LINUX_SYSTEMS = true;
+constexpr const bool HANDLE_WINDOWS_SYSTEMS = true;
 
 }
+
+#endif

--- a/config/engine.version.hpp
+++ b/config/engine.version.hpp
@@ -1,7 +1,4 @@
-#ifdef ENGINE_VERSION_HPP
-#    undef ENGINE_VERSION_HPP
-#endif
-
+#ifndef ENGINE_VERSION_HPP
 #define ENGINE_VERSION_HPP
 
 namespace EngineVersion
@@ -10,9 +7,11 @@ namespace EngineVersion
 // OSGE version manager.
 // There is nothing to change here except if you updated the engine.
 // Track the updates at: https://github.com/ArchorByte/osge.
-constexpr int ENGINE_VERSION_VARIANT = 1;
-constexpr int ENGINE_VERSION_MAJOR = 0;
-constexpr int ENGINE_VERSION_MINOR = 0;
-constexpr int ENGINE_VERSION_PATCH = 0;
+constexpr const int ENGINE_VERSION_VARIANT = 1;
+constexpr const int ENGINE_VERSION_MAJOR = 0;
+constexpr const int ENGINE_VERSION_MINOR = 0;
+constexpr const int ENGINE_VERSION_PATCH = 0;
 
 }
+
+#endif

--- a/config/game.config.hpp
+++ b/config/game.config.hpp
@@ -1,7 +1,4 @@
-#ifdef GAME_CONFIG_HPP
-#    undef GAME_CONFIG_HPP
-#endif
-
+#ifndef GAME_CONFIG_HPP
 #define GAME_CONFIG_HPP
 
 namespace GameConfig
@@ -9,10 +6,12 @@ namespace GameConfig
 
 // Your game info.
 // Default credentials: "New OSGE project" v1.0.0.0.
-constexpr char* GAME_TITLE = "New OSGE project";
-constexpr int GAME_VERSION_VARIANT = 1;
-constexpr int GAME_VERSION_MAJOR = 0;
-constexpr int GAME_VERSION_MINOR = 0;
-constexpr int GAME_VERSION_PATCH = 0;
+constexpr const char* GAME_TITLE = "New OSGE project";
+constexpr const int GAME_VERSION_VARIANT = 1;
+constexpr const int GAME_VERSION_MAJOR = 0;
+constexpr const int GAME_VERSION_MINOR = 0;
+constexpr const int GAME_VERSION_PATCH = 0;
 
 }
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -50,7 +50,7 @@ int main()
         // We "reset" the logs file by deleting it if it already exists.
         if constexpr (EngineConfig::ENABLE_LOGS_FILE)
         {
-            std::string logs_file_name = EngineConfig::LOGS_FILE_NAME;
+            std::string logs_file_name = std::string(EngineConfig::LOGS_FILE_NAME);
 
             if (std::filesystem::exists(logs_file_name))
                 std::filesystem::remove(logs_file_name);

--- a/vulkan/core/vulkan.instance.cpp
+++ b/vulkan/core/vulkan.instance.cpp
@@ -23,7 +23,7 @@ VkInstance create_vulkan_instance
 )
 {
     log("Creating a Vulkan instance..");
-    std::string game_name = GameConfig::GAME_TITLE;
+    std::string game_name = std::string(GameConfig::GAME_TITLE);
 
     if constexpr (EngineConfig::DEBUG_MODE)
         game_name += " - Debug Mode";


### PR DESCRIPTION
* Fixed compilation warnings coming from the config files.
* Fixed the flag definition verification.
* Added the conversion from char* to string in the main and Vulkan instance scripts.
* Locked the values in the config files by simply adding "const" to the flags.