### PR TITLE
Descriptor count validation layers fix

### DIFF
--- a/shaders/default.frag
+++ b/shaders/default.frag
@@ -1,6 +1,6 @@
 #version 450
 
-layout(binding = 1) uniform sampler2D texture_sampler[3];
+layout(binding = 1) uniform sampler2D texture_sampler[2];
 layout(push_constant) uniform PushConstants {
     int selected_texture;
 } pushConstants;


### PR DESCRIPTION
* Adjusted the amount of texture samplers required by the shader file to get rid of the validation layers error (#44).